### PR TITLE
增加对kook的Post请求

### DIFF
--- a/app/core/action/message.go
+++ b/app/core/action/message.go
@@ -1,8 +1,12 @@
 package action
 
 import (
+	"encoding/json"
+
 	"github.com/aimerny/kook-go/app/common"
+	"github.com/aimerny/kook-go/app/core/helper"
 	"github.com/aimerny/kook-go/app/core/model"
+	"github.com/sirupsen/logrus"
 )
 
 func MessageList() {
@@ -13,12 +17,31 @@ func MessageDetail() {
 
 }
 
-func MessageSend(req *model.MessageCreateReq) {
-	go doPost(common.MessageCreate, req)
+func MessageSend(req *model.MessageCreateReq) *model.MessageCreateResp {
+	response, err := helper.Post(common.BaseUrl+common.V3Url+common.MessageCreate, &req)
+	if err != nil {
+		return nil
+	}
+	var result *model.KookResponse[*model.MessageCreateResp]
+	err = json.Unmarshal(response, &result)
+	if result.Code != 0 {
+		return nil
+	}
+	return result.Data
 }
 
-func MessageUpdate() {
-
+func MessageUpdate(req *model.MessageUpdateReq) error {
+	logrus.Println("开始更新消息msg_id:", req.MsgId)
+	response, err := helper.Post(common.BaseUrl+common.V3Url+common.MessageUpdate, &req)
+	if err != nil {
+		return err
+	}
+	var result *model.KookResponse[interface{}]
+	err = json.Unmarshal(response, &result)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func MessageDelete() {

--- a/app/core/model/dto.go
+++ b/app/core/model/dto.go
@@ -1,5 +1,11 @@
 package model
 
+type KookResponse[T interface{}] struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    T      `json:"data"`
+}
+
 // ==== Message ====
 
 type MessageCreateReq struct {
@@ -9,6 +15,12 @@ type MessageCreateReq struct {
 	Quote        string    `json:"quote"`
 	Nonce        string    `json:"nonce"`
 	TempTargetId string    `json:"temp_target_id"`
+}
+
+type MessageCreateResp struct {
+	MsgId       string `json:"msg_id"`
+	MsgTimestap int    `json:"msg_timestamp"`
+	Nonce       string `json:"nonce"`
 }
 
 type MessageUpdateReq struct {


### PR DESCRIPTION
### ✨ 更新：消息发送并返回msg_id和更新消息

#### 变更内容：
1. **新增 `MessageSend` 函数**：
    - 用于发送消息。
    - 包含请求处理和响应解析。
    - 使用 `helper.Post` 进行 HTTP 请求。
    - 添加 JSON 反序列化进行响应处理。

2. **新增 `MessageUpdate` 函数**：
    - 用于更新消息。
    - 包含日志记录和错误处理。
    - 使用 `helper.Post` 进行 HTTP 请求。
    - 添加 JSON 反序列化进行响应处理。

#### 具体实现：
- 在 `message.go` 文件中新增了 `MessageSend` 和 `MessageUpdate` 函数。
- `MessageSend` 函数接受 `*model.MessageCreateReq` 类型的请求参数，返回 `*model.MessageCreateResp` 类型的响应。
- `MessageUpdate` 函数接受 `*model.MessageUpdateReq` 类型的请求参数，返回 `error` 类型的错误信息（如果有）。
