### PR TITLE
增加post请求，以及用户相关事件结构体用于mapstructure

### DIFF
--- a/app/core/action/message.go
+++ b/app/core/action/message.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"encoding/json"
+	"errors"
 
 	"github.com/aimerny/kook-go/app/common"
 	"github.com/aimerny/kook-go/app/core/helper"
@@ -17,17 +18,20 @@ func MessageDetail() {
 
 }
 
-func MessageSend(req *model.MessageCreateReq) *model.MessageCreateResp {
+func MessageSend(req *model.MessageCreateReq) (*model.MessageCreateResp, error) {
 	response, err := helper.Post(common.BaseUrl+common.V3Url+common.MessageCreate, &req)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	var result *model.KookResponse[*model.MessageCreateResp]
 	err = json.Unmarshal(response, &result)
-	if result.Code != 0 {
-		return nil
+	if err != nil {
+		return nil, err
 	}
-	return result.Data
+	if result.Code != 0 {
+		return nil, errors.New(result.Message)
+	}
+	return result.Data, nil
 }
 
 func MessageUpdate(req *model.MessageUpdateReq) error {

--- a/app/core/action/message.go
+++ b/app/core/action/message.go
@@ -1,8 +1,12 @@
 package action
 
 import (
+	"encoding/json"
+
 	"github.com/aimerny/kook-go/app/common"
+	"github.com/aimerny/kook-go/app/core/helper"
 	"github.com/aimerny/kook-go/app/core/model"
+	"github.com/sirupsen/logrus"
 )
 
 func MessageList() {
@@ -13,12 +17,31 @@ func MessageDetail() {
 
 }
 
-func MessageSend(req *model.MessageCreateReq) {
-	go doPost(common.MessageCreate, req)
+func MessageSend(req *model.MessageCreateReq) *model.MessageCreateResp {
+	response, err := helper.Post(common.BaseUrl+common.V3Url+common.MessageCreate, &req)
+	if err != nil {
+		return nil
+	}
+	var result *model.KookResponse[*model.MessageCreateResp]
+	err = json.Unmarshal(response, &result)
+	if result.Code != 0 {
+		return nil
+	}
+	return result.Data
 }
 
-func MessageUpdate() {
-
+func MessageUpdate(req *model.MessageUpdateReq) error {
+	logrus.Println("开始更新消息msg_id:", req.MsgId)
+	response, err := helper.Post(common.BaseUrl+common.V3Url+common.MessageUpdate, &req)
+	if err != nil {
+		return err
+	}
+	var result *model.KookResponse[interface{}]
+	err = json.Unmarshal(response, &result)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func MessageDelete() {

--- a/app/core/action/message.go
+++ b/app/core/action/message.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aimerny/kook-go/app/common"
 	"github.com/aimerny/kook-go/app/core/helper"
 	"github.com/aimerny/kook-go/app/core/model"
-	"github.com/sirupsen/logrus"
 )
 
 func MessageList() {
@@ -35,7 +34,6 @@ func MessageSend(req *model.MessageCreateReq) (*model.MessageCreateResp, error) 
 }
 
 func MessageUpdate(req *model.MessageUpdateReq) error {
-	logrus.Println("开始更新消息msg_id:", req.MsgId)
 	response, err := helper.Post(common.BaseUrl+common.V3Url+common.MessageUpdate, &req)
 	if err != nil {
 		return err
@@ -44,6 +42,9 @@ func MessageUpdate(req *model.MessageUpdateReq) error {
 	err = json.Unmarshal(response, &result)
 	if err != nil {
 		return err
+	}
+	if result.Code != 0 {
+		return errors.New(result.Message)
 	}
 	return nil
 }

--- a/app/core/helper/http_helper.go
+++ b/app/core/helper/http_helper.go
@@ -29,6 +29,7 @@ func Get(url string) (*http.Response, error) {
 	request.Header.Set("Authorization", fmt.Sprintf("Bot %s", globalToken))
 	return client.Do(request)
 }
+
 func Post(url string, body interface{}) ([]byte, error) {
 	client := &http.Client{}
 	bodyData, err := json.Marshal(body)

--- a/app/core/model/card.go
+++ b/app/core/model/card.go
@@ -34,6 +34,7 @@ type CardModule struct {
 	Mode      string        `json:"mode,omitempty"`
 	Accessory *CardModule   `json:"accessory,omitempty"`
 	Value     string        `json:"value,omitempty"`
+	Click     string        `json:"click,omitempty"`
 	Src       string        `json:"src,omitempty"`
 	StartTime int64         `json:"startTime,omitempty"`
 	EndTime   int64         `json:"endTime,omitempty"`

--- a/app/core/model/dto.go
+++ b/app/core/model/dto.go
@@ -1,5 +1,11 @@
 package model
 
+type KookResponse[T interface{}] struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    T      `json:"data"`
+}
+
 // ==== Message ====
 
 type MessageCreateReq struct {
@@ -9,6 +15,12 @@ type MessageCreateReq struct {
 	Quote        string    `json:"quote"`
 	Nonce        string    `json:"nonce"`
 	TempTargetId string    `json:"temp_target_id"`
+}
+
+type MessageCreateResp struct {
+	MsgId       string `json:"msg_id"`
+	MsgTimestap int    `json:"msg_timestamp"`
+	Nonce       string `json:"nonce"`
 }
 
 type MessageUpdateReq struct {

--- a/app/core/model/event.go
+++ b/app/core/model/event.go
@@ -1,6 +1,8 @@
 package model
 
-import "github.com/mitchellh/mapstructure"
+import (
+	"github.com/mitchellh/mapstructure"
+)
 
 type Event struct {
 	ChannelType  ChannelEventType `json:"channel_type"`
@@ -11,7 +13,7 @@ type Event struct {
 	MsgId        string           `json:"msg_id"`
 	MsgTimestamp int              `json:"msg_timestamp"`
 	Nonce        string           `json:"nonce"`
-	Extra        any              `json:"extra"`
+	Extra        interface{}      `json:"extra"`
 }
 
 type ChannelEventType string
@@ -36,20 +38,66 @@ const (
 )
 
 type UserExtra struct {
-	EventType    EventType `json:"type" mapstructure:"event_type"`
-	GuildId      string    `json:"guild_id" mapstructure:"guild_id"`
-	ChannelName  string    `json:"channel_name" mapstructure:"channel_name"`
-	Mention      []string  `json:"mention" mapstructure:"mention"`
-	MentionAll   bool      `json:"mention_all" mapstructure:"mention_all"`
-	MentionRoles []any     `json:"mention_roles" mapstructure:"mention_roles"`
-	MentionHere  bool      `json:"mention_here" mapstructure:"mention_here"`
-	Author       User      `json:"author" mapstructure:"author"`
+	EventType    EventType     `json:"type" mapstructure:"event_type"`
+	GuildId      string        `json:"guild_id" mapstructure:"guild_id"`
+	ChannelName  string        `json:"channel_name" mapstructure:"channel_name"`
+	Mention      []string      `json:"mention" mapstructure:"mention"`
+	MentionAll   bool          `json:"mention_all" mapstructure:"mention_all"`
+	MentionRoles []interface{} `json:"mention_roles" mapstructure:"mention_roles"`
+	MentionHere  bool          `json:"mention_here" mapstructure:"mention_here"`
+	Author       User          `json:"author" mapstructure:"author"`
 }
 
 type SystemExtra struct {
-	SystemEventType string         `json:"type"`
-	Body            map[string]any `json:"body"`
+	SystemEventType string                 `json:"type"`
+	Body            map[string]interface{} `json:"body"`
 }
+
+// system extra Body
+// ==== 用户相关事件 ====
+// 用户加入语音频道
+type JoinedChannel struct {
+	UserId    string `json:"user_id" mapstructure:"user_id"`
+	ChannelId string `json:"channel_id" mapstructure:"channel_id"`
+	JoinedAt  int    `json:"joined_at" mapstructure:"joined_at"`
+}
+
+// 用户退出语音频道
+type ExitedChannel struct {
+	UserId    string `json:"user_id" mapstructure:"user_id"`
+	ChannelId string `json:"channel_id" mapstructure:"channel_id"`
+	ExitedAt  int    `json:"exited_at" mapstructure:"exited_at"`
+}
+
+// 用户信息更新
+type UserUpdated struct {
+	UserId   string `json:"user_id"`
+	UserName string `json:"username" mapstructure:"username"`
+	Avatar   int    `json:"avatar" mapstructure:"avatar"`
+}
+
+// 自己新加入服务器
+type SelfJoinedGuild struct {
+	GuildId string `json:"guild_id" mapstructure:"guild_id"`
+	State   string `json:"state" mapstructure:"state"`
+}
+
+// 自己退出服务器
+type SelfExitedGuild struct {
+	GuildId string `json:"guild_id" mapstructure:"guild_id"`
+}
+
+// Card 消息中的 Button 点击事件
+type MessageBtnClick struct {
+	GuildId  string `json:"guild_id" mapstructure:"guild_id"`
+	MsgId    string `json:"msg_id" mapstructure:"msg_id"`
+	TargetId string `json:"target_id" mapstructure:"target_id"`
+	UserId   string `json:"user_id" mapstructure:"user_id"`
+	UserInfo User   `json:"user_info" mapstructure:"user_info"`
+	Value    string `json:"value" mapstructure:"value"`
+}
+
+// ==== 用户相关事件 ==== 结束
 
 func (e *Event) GetUserExtra() *UserExtra {
 	if e.EventType != EventTypeSystem {
@@ -64,6 +112,7 @@ func (e *Event) GetSystemExtra() *SystemExtra {
 	if e.EventType == EventTypeSystem {
 		extra := &SystemExtra{}
 		mapstructure.Decode(e.Extra, extra)
+		return extra
 	}
 	return nil
 }


### PR DESCRIPTION
:sparkles: 新增用户相关事件结构体用于mapstructure
- 添加 `JoinedChannel` 结构体，用于表示用户加入语音频道事件
- 添加 `ExitedChannel` 结构体，用于表示用户退出语音频道事件
- 添加 `UserUpdated` 结构体，用于表示用户信息更新事件
- 添加 `SelfJoinedGuild` 结构体，用于表示自己新加入服务器事件
- 添加 `SelfExitedGuild` 结构体，用于表示自己退出服务器事件
- 添加 `MessageBtnClick` 结构体，用于表示消息中的按钮点击事件

:bug: 修复 `GetSystemExtra` 返回问题
- 修复 `GetSystemExtra` 方法在事件类型为系统事件时返回 `SystemExtra` 的问题"