### PR TITLE
feat: :sparkles: improve some features of the card module

### DIFF
--- a/app/core/model/card.go
+++ b/app/core/model/card.go
@@ -26,15 +26,20 @@ const (
 type CardModule struct {
 	Type      string        `json:"type"`
 	Theme     CardThemeType `json:"theme,omitempty"`
+	Title     string        `json:"title,omitempty"`
 	Text      CardText      `json:"text,omitempty"`
 	Size      CardSize      `json:"size,omitempty"`
 	Modules   []CardModule  `json:"modules,omitempty"`
 	Fields    []CardModule  `json:"fields,omitempty"`
 	Elements  []CardModule  `json:"elements,omitempty"`
+	Content   string        `json:"content,omitempty"`
 	Mode      string        `json:"mode,omitempty"`
 	Accessory *CardModule   `json:"accessory,omitempty"`
 	Value     string        `json:"value,omitempty"`
+	Cover     string        `json:"cover,omitempty"`
 	Click     string        `json:"click,omitempty"`
+	Code      string        `json:"code,omitempty"`
+	Circle    bool          `json:"circle,omitempty"`
 	Src       string        `json:"src,omitempty"`
 	StartTime int64         `json:"startTime,omitempty"`
 	EndTime   int64         `json:"endTime,omitempty"`
@@ -84,6 +89,13 @@ func NewKMarkdown(content string) *CardModule {
 			Type:    "kmarkdown",
 			Content: content,
 		},
+	}
+}
+
+func NewInvite(code string) *CardModule {
+	return &CardModule{
+		Type: "invite",
+		Code: code,
 	}
 }
 


### PR DESCRIPTION
feat(card): 完善卡片模块

```go
type CardModule struct {
	Type      string        `json:"type"`
	Theme     CardThemeType `json:"theme,omitempty"`
	Title     string        `json:"title,omitempty"` //音频文件标题
	Text      CardText      `json:"text,omitempty"`
	Size      CardSize      `json:"size,omitempty"`
	Modules   []CardModule  `json:"modules,omitempty"`
	Fields    []CardModule  `json:"fields,omitempty"`
	Elements  []CardModule  `json:"elements,omitempty"`
	Content   string        `json:"content,omitempty"` //elements中有用
	Mode      string        `json:"mode,omitempty"`
	Accessory *CardModule   `json:"accessory,omitempty"`
	Value     string        `json:"value,omitempty"`
	Cover     string        `json:"cover,omitempty"` //音频文件封面
	Click     string        `json:"click,omitempty"`
	Code      string        `json:"code,omitempty"` //邀请码或链接
	Circle    bool          `json:"circle,omitempty"` //图片修饰
	Src       string        `json:"src,omitempty"`
	StartTime int64         `json:"startTime,omitempty"`
	EndTime   int64         `json:"endTime,omitempty"`
}
```
- :bug: `Content` 支持elments中使用kmarkdown
- :sparkles: `NewInvite` 用于处理带邀请码的邀请卡片
