### PR TITLE
fix: 🐛 Heartbeat scheduled task repeats during reconnection

### DIFF
--- a/app/core/session/session_handle.go
+++ b/app/core/session/session_handle.go
@@ -146,6 +146,7 @@ func (s *State) wsConnectSuccess() {
 
 func (s *State) wsConnectFail() error {
 	log.Errorf("ws connect fail")
+	s.HeartBeatCron.Clear()
 	s.FSM.Event(context.Background(), EventWsConnectFail)
 	return nil
 }


### PR DESCRIPTION
1. `HeartBeatCron`每次重新连接时都会重复添加定时任务，重连过多会导致疯狂的ping！
2. 在`wsConnectFail`触发时能够及时对任务进行清除操作

问题示例：
```go
#断开时未能及时清理定时任务
INFO[2024-09-03 00:34:41] wsConnectOk                                  
INFO[2024-09-03 00:34:41] Heart beat checker inited                    
INFO[2024-09-03 00:34:41] resume session ok.                           
INFO[2024-09-03 00:34:45] send Ping                                     ping="{\"s\":2,\"sn\":0,\"d\":null}"
INFO[2024-09-03 00:34:45] pong!                                        
INFO[2024-09-03 00:34:54] send Ping                                     ping="{\"s\":2,\"sn\":0,\"d\":null}"
INFO[2024-09-03 00:34:54] pong!                                        
INFO[2024-09-03 00:34:58] send Ping                                     ping="{\"s\":2,\"sn\":0,\"d\":null}"
INFO[2024-09-03 00:34:58] pong!                                        
INFO[2024-09-03 00:35:02] send Ping                                     ping="{\"s\":2,\"sn\":0,\"d\":null}"
INFO[2024-09-03 00:35:02] pong!                                        
INFO[2024-09-03 00:35:11] send Ping                                     ping="{\"s\":2,\"sn\":0,\"d\":null}"
INFO[2024-09-03 00:35:11] pong!                                        
INFO[2024-09-03 00:35:15] send Ping                                     ping="{\"s\":2,\"sn\":0,\"d\":null}"
INFO[2024-09-03 00:35:15] pong!        
```